### PR TITLE
fix: refresh sentry nonce every 500ms

### DIFF
--- a/node/validator.go
+++ b/node/validator.go
@@ -94,7 +94,7 @@ func NewValidator(config ValidatorConfig) Validator {
 		payAccount: acc,
 	}
 
-	if _, err := v.scheduler.Every(10).Second().Do(func() {
+	if _, err := v.scheduler.Every(500).Milliseconds().Do(func() {
 		v.refresh()
 	}); err != nil {
 		log.Debugw("error while setting up scheduler", "err", err)


### PR DESCRIPTION
### Description

for [BEP-341](https://www.bnbchain.org/en/blog/bep-341-consecutive-block-production ) applied on bsc-testnet, one validator sentry would be used multiple times in 10s.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
