### PR TITLE
chore: change go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.21-alpine AS builder
+FROM public.ecr.aws/docker/library/golang:1.23-alpine AS builder
 
 ENV GO111MODULE=on \
     CGO_ENABLED=1 \


### PR DESCRIPTION
### Description

chore: change go version in Dockerfile

### Rationale

v1.5.13 release failed to generate ` Packages` caused of go version in `Dockerfile`

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
