### PR TITLE
log: redirect logs to stderr when RootDir empty

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,11 +78,7 @@ func main() {
 
 func initLogger(cfg *config.LogConfig) {
 	lvl, _ := log.ParseLevel(cfg.Level)
-	var path string
-	if cfg.RootDir != "" {
-		path = log.StandardizePath(cfg.RootDir, serviceName)
-	}
-	log.Init(lvl, path)
+	log.Init(lvl, log.StandardizePath(cfg.RootDir, serviceName))
 }
 
 func openPrometheusAndPprof(addr string) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,7 +78,11 @@ func main() {
 
 func initLogger(cfg *config.LogConfig) {
 	lvl, _ := log.ParseLevel(cfg.Level)
-	log.Init(lvl, log.StandardizePath(cfg.RootDir, serviceName))
+	var path string
+	if cfg.RootDir != "" {
+		path = log.StandardizePath(cfg.RootDir, serviceName)
+	}
+	log.Init(lvl, path)
 }
 
 func openPrometheusAndPprof(addr string) {

--- a/config/config.go
+++ b/config/config.go
@@ -62,8 +62,11 @@ type DebugConfig struct {
 }
 
 type LogConfig struct {
+	// RootDir is the directory for log files.
+	// If empty, logs are written to stderr only.
 	RootDir string
-	Level   string
+
+	Level string
 }
 
 var defaultConfig = Config{
@@ -71,7 +74,7 @@ var defaultConfig = Config{
 		ListenAddr: ":6060",
 	},
 	Log: LogConfig{
-		RootDir: "",
+		RootDir: "./logs",
 		Level:   "debug",
 	},
 }

--- a/config/config.go
+++ b/config/config.go
@@ -71,7 +71,7 @@ var defaultConfig = Config{
 		ListenAddr: ":6060",
 	},
 	Log: LogConfig{
-		RootDir: "./logs",
+		RootDir: "",
 		Level:   "debug",
 	},
 }

--- a/configs/config-example.toml
+++ b/configs/config-example.toml
@@ -1,3 +1,7 @@
+[Log]
+Level = "info"   # Log level: debug, info, warn, error
+RootDir = "./logs" # Directory for log files. Set to "" to write to stderr only (e.g. for journald).
+
 [Service]
 HTTPListenAddr = "localhost:8555" # The address to listen on for HTTP requests.
 RPCConcurrency = 100 # The maximum number of concurrent requests.

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/bnb-chain/bsc-mev-sentry/log"
 	"github.com/bnb-chain/bsc-mev-sentry/log/internal/types"
 )
@@ -107,4 +109,21 @@ func Test_With(t *testing.T) {
 	log.With("t", 1, "hhh", "xxx", "hhh", "www").Warn("test")
 
 	printLogContent(t)
+}
+
+// Verify that calling Init with an
+// empty path does not create any files or directories.
+// The logger falls back to stderr instead of creating a directory.
+// This behavior lets the process supervisor (e.g. journald) handle log capture.
+func Test_InitWithEmptyPathFallsBackToStderr(t *testing.T) {
+	entriesBefore, err := os.ReadDir(".")
+	assert.NoError(t, err)
+
+	log.Init(types.InfoLevel, "")
+	log.Info("fallback to stderr")
+
+	entriesAfter, err := os.ReadDir(".")
+	assert.NoError(t, err)
+	assert.Equal(t, len(entriesBefore), len(entriesAfter),
+		"Init with empty path must not create any files or directories")
 }

--- a/log/path.go
+++ b/log/path.go
@@ -11,6 +11,9 @@ import (
 // the returned path is consistent and unified.
 // The path after decoration will be `<root>/<node_ip>/<local_ip>/<service_name>.log`
 func StandardizePath(root, serviceName string) string {
+	if root == "" {
+		return ""
+	}
 	return filepath.Join(root, os.Getenv("NODE_IP"), getLocalIP(), fmt.Sprintf("%s.log", serviceName))
 }
 

--- a/log/path_test.go
+++ b/log/path_test.go
@@ -15,3 +15,10 @@ func TestStabdardizePath(t *testing.T) {
 	reg := regexp.MustCompile(fmt.Sprintf(`\/tmp\/%s\/mockSrv.log`, ipv4))
 	assert.Regexp(t, reg, StandardizePath(root, serviceName))
 }
+
+func TestStandardizePath_EmptyRoot(t *testing.T) {
+	// An empty root must return "" so that log.Init skips file logging
+	// and falls back to stderr. This is the intended behaviour when
+	// RootDir is not set in the [Log] config section.
+	assert.Equal(t, "", StandardizePath("", "mockSrv"))
+}


### PR DESCRIPTION

### Description

When RootDir is omitted from the `[Log]` config section, the logger should write to stderr and let the process supervisor (e.g. `journald`) handle log capture. Previously,`initLogger` unconditionally called `StandardizePath` even when `RootDir` was empty. `StandardizePath` derives a path from the node's local IP when given an empty root, so it never returns an empty string — causing Init to attempt `os.MkdirAll` on a path like `192.168.1.1/bsc-mev-sentry.log`. On systems with a read-only working directory (e.g. systemd services with `DynamicUser=yes` and no `LogsDirectory`), this results in a panic at startup.

### Rationale

File logging should be opt-in. Users running `bsc-mev-sentry` under `systemd` with `StandardOutput=journal` / `StandardError=journal` already have log capture handled by `journald`, which provides automatic rotation and retention. Requiring a writable log directory in that setup serves no purpose and makes the service fail to start if no writable directory is configured.
Changing the default `RootDir` to `""` and guarding the `StandardizePath` call makes the safer, simpler deployment the default — no log directory needed unless explicitly configured.

### Example

Without `RootDir` in the config:

```toml
[Log]
Level = "info"
```

**Before:** service panics at startup with `make log dir failed: mkdir <node-ip>: read-only file system`

**After:** service starts cleanly and writes JSON log lines to stderr, which systemd/journald
captures via `SyslogIdentifier`.

### Changes

Notable changes:
* `config/config.go`: changed default `RootDir` from `"./logs"` to `""` — file logging is now opt-in; omitting `RootDir` is a valid configuration
* `cmd/main.go`: `initLogger` now guards the `StandardizePath` call behind `cfg.RootDir != ""`, so an empty root no longer produces a path derived from the node's local IP
* `log/logger_test.go`: added `Test_InitWithEmptyPathFallsBackToStderr` to assert that `Init("")` creates no filesystem artifacts
